### PR TITLE
Hotfix: for "Pick Media" dialog for v1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "json-loader": "^0.5.4",
     "mongodb": "^3.1.10",
     "multer": "^1.4.1",
-    "sass": "^1.16.0",
+    "sass": "1.25.0",
     "semver": "^5.6.0",
     "webpack": "^4.28.1",
     "webpack-cli": "^3.3.0"

--- a/style/modal/mediaBrowser.scss
+++ b/style/modal/mediaBrowser.scss
@@ -6,7 +6,7 @@
     &__body {
         display: flex;
         padding: 0;
-        
+
         @include tablet {
             display: block;
         }
@@ -56,15 +56,16 @@
         height: 20rem;
         position: relative;
         border: 1px solid transparent;
+        display: flex;
 
         &:hover {
             border-color: var(--color-action-500);
         }
-        
+
         @include tablet {
             max-width: calc(100% / 2);
         }
-        
+
         @include phone {
             max-width: 100%;
         }
@@ -93,7 +94,7 @@
             color: var(--color-default-text);
             border-radius: var(--border-radius-small);
         }
-        
+
         &:hover &__name {
             background-color: var(--color-action-500);
             color: var(--color-action-text);

--- a/style/widget/media.scss
+++ b/style/widget/media.scss
@@ -2,7 +2,8 @@
     max-width: 100%;
     display: flex;
     flex-direction: column;
-    
+    height: 100%;
+
     &.small {
         width: 10rem;
     }
@@ -10,7 +11,7 @@
     &.small &__preview {
         height: 10rem;
     }
-   
+
     &__placeholder {
         @include spinner;
     }
@@ -35,7 +36,7 @@
 
         &:not(.readonly) {
             cursor: pointer;
-            
+
             &:hover {
                 border-color: var(--color-action-500);
                 background-color: var(--color-action-500);
@@ -51,6 +52,9 @@
             font-size: 2rem;
             position: relative;
             z-index: 100;
+            object-fit: contain;
+            max-height: 100%;
+            max-width: 100%;
         }
     }
 


### PR DESCRIPTION
This pull request contains a hotfix for version 1.3.x to fix an issue with the "Pick Media" dialog where the view was broken to the extend of inaccessibility due to portrait images flowing far beyond their containers. With the help of `object-fit` and some `max-width` and `max-height`s this issue is solved.

**Note: this fix is _not_ necessary for version 1.4**

Another change is the fixation of the dev dependency "sass" to a specific version since newer versions break the build process (goes mostly unnoticed with older installations because theres a high chance that `package-json.lock` refers to a compatible version).

Note: some of the changes are merely removing spaces in empty lines due to automatic beautifying by my editor. ;)